### PR TITLE
Remove redundant word

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+dist: trusty
 jdk:
   - oraclejdk8
 

--- a/docs-out/semanticdb/guide.md
+++ b/docs-out/semanticdb/guide.md
@@ -81,8 +81,8 @@ $ metac Test.scala
 `metac` is a thin wrapper over the Scala compiler. It supports the same
 command-line arguments as `scalac` supports, but instead of generating .class
 files it generates .semanticdb files. Newer versions of Metac may also generate
-an accompanying .semanticidx file, but it's an experimental feature, so we won't
-won't be discussing it in this document.
+an accompanying .semanticidx file, but it's an experimental feature, so we won't 
+be discussing it in this document.
 
 ```
 $ tree


### PR DESCRIPTION
I was reading the docs and found a redundant word in [Example](https://scalameta.org/docs/semanticdb/guide.html#example) section. When I committed this change, the build failed. So, added `dist: trusty` to fix the travis build.