### PR TITLE
update dependencies and remove reference to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-See http://scalameta.org/tutorial/.
+# Scalameta Website Source
+
+See the website: [https://scalameta.org](https://scalameta.org)

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,11 @@
-def scalameta = "4.2.3"
-def scalafix = "0.9.7"
+def scalameta = "4.3.0"
+def scalafix = "0.9.11"
 def scala212 = "2.12.10"
 
 inThisBuild(
   List(
     organization := "org.scalameta",
     scalaVersion := scala212,
-    libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.5" % Test
-    ),
     resolvers += Resolver.sonatypeRepo("releases")
   )
 )

--- a/docs-out/trees/guide.md
+++ b/docs-out/trees/guide.md
@@ -23,10 +23,10 @@ Scala 2.11, Scala 2.12, Scala.js and Scala Native.
 
 ```scala
 // build.sbt
-libraryDependencies += "org.scalameta" %% "scalameta" % "4.2.3"
+libraryDependencies += "org.scalameta" %% "scalameta" % "4.3.0"
 
 // For Scala.js, Scala Native
-libraryDependencies += "org.scalameta" %%% "scalameta" % "4.2.3"
+libraryDependencies += "org.scalameta" %%% "scalameta" % "4.3.0"
 ```
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scalameta/scalameta_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.scalameta/scalameta_2.12)
@@ -44,7 +44,7 @@ A great way to experiment with Scalameta is to use the
 
 ```scala
 // Ammonite REPL
-import $ivy.`org.scalameta::scalameta:4.2.3`, scala.meta._
+import $ivy.`org.scalameta::scalameta:4.3.0`, scala.meta._
 ```
 
 ### ScalaFiddle

--- a/docs-out/trees/scaladoc.md
+++ b/docs-out/trees/scaladoc.md
@@ -5,9 +5,9 @@ title: Scaladoc
 
 Scaladoc documentation for individual modules can be browsed on static.javadoc.io:
 
-* [Trees](https://static.javadoc.io/org.scalameta/trees_2.12/4.2.3/scala/meta/index.html): syntax trees such as `Source`, `Term` and `Type`.
-* [Scalameta](https://static.javadoc.io/org.scalameta/scalameta_2.12/4.2.3/scala/meta/index.html): umbrella API with extension methods such as `.parse[Source]`.
-* [Testkit](https://static.javadoc.io/org.scalameta/testkit_2.12/4.2.3/scala/meta/index.html): utility methods for testing with Scalameta.
-* [Parsers](https://static.javadoc.io/org.scalameta/parsers_2.12/4.2.3/scala/meta/index.html): internal parser APIs and implementation.
-* [Common](https://static.javadoc.io/org.scalameta/common_2.12/4.2.3/scala/meta/index.html): internal APIs.
+* [Trees](https://static.javadoc.io/org.scalameta/trees_2.12/4.3.0/scala/meta/index.html): syntax trees such as `Source`, `Term` and `Type`.
+* [Scalameta](https://static.javadoc.io/org.scalameta/scalameta_2.12/4.3.0/scala/meta/index.html): umbrella API with extension methods such as `.parse[Source]`.
+* [Testkit](https://static.javadoc.io/org.scalameta/testkit_2.12/4.3.0/scala/meta/index.html): utility methods for testing with Scalameta.
+* [Parsers](https://static.javadoc.io/org.scalameta/parsers_2.12/4.3.0/scala/meta/index.html): internal parser APIs and implementation.
+* [Common](https://static.javadoc.io/org.scalameta/common_2.12/4.3.0/scala/meta/index.html): internal APIs.
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.7

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,6 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "1.12.0"
+    "docusaurus": "1.14.4"
   }
 }


### PR DESCRIPTION
The versions were out of date. This PR bumps the versions of scalameta and scalafix that are referenced throughout the documentation. I also removed the reference to tutorial. I know it started that way, but maybe it's time to rename the repo?

Couple other thoughts/questions:

1. In order to be consistent across the scalameta repos (I know you have reasons why this isn't just part of scalameta), but does this repo and the actual github.io repo that publishes this need to be separate? Would it be easier to just make them one repo and have this one both build and deploy like the other sites?
2. My main reason for this pr and questions would be to help newcomers find this content, contribute to it, and make sure the documentation stays up to date. I find the whole scalameta ecosystem fascinating, but as a newcomer to this type of ecosystem, it can be really hard to navigate, and I think keeping the docs and such up to date and orderly are important. I'm more than happy to change this pr, add to it, move stuff around, etc. Just let me know how you'd like to proceed and I'm happy to help.